### PR TITLE
Add seed script and sample Postman collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ $ npm run test:e2e
 $ npm run test:cov
 ```
 
+## Seed database
+
+Populate the local SQLite database with sample data using:
+
+```bash
+$ npm run seed
+```
+
+## API usage with Postman
+
+Import the `docs/finance-api.postman_collection.json` file into Postman to try all available endpoints.
+
+
 ## Deployment
 
 When you're ready to deploy your NestJS application to production, there are some key steps you can take to ensure it runs as efficiently as possible. Check out the [deployment documentation](https://docs.nestjs.com/deployment) for more information.

--- a/docs/finance-api.postman_collection.json
+++ b/docs/finance-api.postman_collection.json
@@ -1,0 +1,156 @@
+{
+  "info": {
+    "name": "Finance API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Payments",
+      "item": [
+        {
+          "name": "Get all payments",
+          "request": { "method": "GET", "url": "{{baseUrl}}/payments" }
+        },
+        {
+          "name": "Create payment",
+          "request": {
+            "method": "POST",
+            "header": [{"key": "Content-Type", "value": "application/json"}],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"resident\": \"<residentId>\",\n  \"category\": \"<categoryId>\",\n  \"amount\": 100,\n  \"method\": \"TRANSFER\"\n}"
+            },
+            "url": "{{baseUrl}}/payments"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Categories",
+      "item": [
+        { "name": "Get all categories", "request": { "method": "GET", "url": "{{baseUrl}}/categories" } },
+        {
+          "name": "Create category",
+          "request": {
+            "method": "POST",
+            "header": [{"key":"Content-Type","value":"application/json"}],
+            "body": {"mode":"raw","raw":"{\n  \"name\": \"Maintenance\",\n  \"type\": \"maintenance\"\n}"},
+            "url": "{{baseUrl}}/categories"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Residents",
+      "item": [
+        { "name": "Get all residents", "request": { "method": "GET", "url": "{{baseUrl}}/residents" } },
+        {
+          "name": "Create resident",
+          "request": {
+            "method": "POST",
+            "header": [{"key":"Content-Type","value":"application/json"}],
+            "body": {"mode":"raw","raw":"{\n  \"name\": \"John Doe\",\n  \"unitNumber\": \"A1\",\n  \"email\": \"john@example.com\"\n}"},
+            "url": "{{baseUrl}}/residents"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Budgets",
+      "item": [
+        { "name": "Get all budgets", "request": { "method": "GET", "url": "{{baseUrl}}/budgets" } },
+        {
+          "name": "Create budget",
+          "request": {
+            "method": "POST",
+            "header": [{"key":"Content-Type","value":"application/json"}],
+            "body": {"mode":"raw","raw":"{\n  \"year\": 2025\n}"},
+            "url": "{{baseUrl}}/budgets"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Provider expenses",
+      "item": [
+        { "name": "Get all provider expenses", "request": { "method": "GET", "url": "{{baseUrl}}/provider-expenses" } },
+        {
+          "name": "Create provider expense",
+          "request": {
+            "method": "POST",
+            "header": [{"key":"Content-Type","value":"application/json"}],
+            "body": {"mode":"raw","raw":"{\n  \"providerName\": \"CleanCo\",\n  \"serviceCategory\": \"<categoryId>\",\n  \"totalAmount\": 300\n}"},
+            "url": "{{baseUrl}}/provider-expenses"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Delinquencies",
+      "item": [
+        { "name": "Get all delinquencies", "request": { "method": "GET", "url": "{{baseUrl}}/delinquencies" } },
+        {
+          "name": "Create delinquency",
+          "request": {
+            "method": "POST",
+            "header": [{"key":"Content-Type","value":"application/json"}],
+            "body": {"mode":"raw","raw":"{\n  \"description\": \"Late fee\",\n  \"amount\": 50\n}"},
+            "url": "{{baseUrl}}/delinquencies"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Extraordinary expenses",
+      "item": [
+        { "name": "Get all extraordinary expenses", "request": { "method": "GET", "url": "{{baseUrl}}/extraordinary-expenses" } },
+        {
+          "name": "Create extraordinary expense",
+          "request": {
+            "method": "POST",
+            "header": [{"key":"Content-Type","value":"application/json"}],
+            "body": {"mode":"raw","raw":"{\n  \"concept\": \"Roof repair\",\n  \"amount\": 2000,\n  \"approvedBy\": \"Board\"\n}"},
+            "url": "{{baseUrl}}/extraordinary-expenses"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Reserve fund transactions",
+      "item": [
+        { "name": "Get all reserve fund transactions", "request": { "method": "GET", "url": "{{baseUrl}}/reserve-fund-transactions" } },
+        {
+          "name": "Create reserve fund transaction",
+          "request": {
+            "method": "POST",
+            "header": [{"key":"Content-Type","value":"application/json"}],
+            "body": {"mode":"raw","raw":"{\n  \"amount\": 500,\n  \"type\": \"INCOME\",\n  \"notes\": \"Initial fund\"\n}"},
+            "url": "{{baseUrl}}/reserve-fund-transactions"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Bank transactions",
+      "item": [
+        { "name": "Get all bank transactions", "request": { "method": "GET", "url": "{{baseUrl}}/bank-transactions" } },
+        {
+          "name": "Create bank transaction",
+          "request": {
+            "method": "POST",
+            "header": [{"key":"Content-Type","value":"application/json"}],
+            "body": {"mode":"raw","raw":"{\n  \"bankDate\": \"2025-01-01\",\n  \"bankAmount\": 500,\n  \"matched\": false\n}"},
+            "url": "{{baseUrl}}/bank-transactions"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Reports",
+      "item": [
+        { "name": "Monthly balance", "request": { "method": "GET", "url": "{{baseUrl}}/reports/monthly-balance?month=1&year=2025" } },
+        { "name": "Income vs expense", "request": { "method": "GET", "url": "{{baseUrl}}/reports/income-expense?start=2025-01-01&end=2025-02-01" } }
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "seed": "ts-node scripts/seed.ts"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,0 +1,84 @@
+import { DataSource } from 'typeorm';
+import { Resident } from '../src/modules/residents/entities/resident.entity';
+import { Category, CategoryType } from '../src/modules/categories/entities/category.entity';
+import { Payment, PaymentMethod } from '../src/modules/payments/entities/payment.entity';
+import { Budget } from '../src/modules/budgets/entities/budget.entity';
+import { BudgetItem } from '../src/modules/budgets/entities/budget-item.entity';
+import { ProviderExpense } from '../src/modules/provider-expenses/entities/provider-expense.entity';
+import { Delinquency } from '../src/modules/delinquencies/entities/delinquency.entity';
+import { ExtraordinaryExpense } from '../src/modules/extraordinary-expenses/entities/extraordinary-expense.entity';
+import { ReserveFundTransaction } from '../src/modules/reserve-fund-transactions/entities/reserve-fund-transaction.entity';
+import { BankTransaction } from '../src/modules/bank-reconciliation/entities/bank-transaction.entity';
+
+const dataSource = new DataSource({
+  type: 'sqlite',
+  database: 'database.sqlite',
+  entities: [__dirname + '/../src/modules/**/*.entity{.ts,.js}'],
+  synchronize: true,
+});
+
+async function seed() {
+  await dataSource.initialize();
+
+  const residentRepo = dataSource.getRepository(Resident);
+  const categoryRepo = dataSource.getRepository(Category);
+  const paymentRepo = dataSource.getRepository(Payment);
+  const budgetRepo = dataSource.getRepository(Budget);
+  const budgetItemRepo = dataSource.getRepository(BudgetItem);
+  const providerExpenseRepo = dataSource.getRepository(ProviderExpense);
+  const delinquencyRepo = dataSource.getRepository(Delinquency);
+  const extraordinaryExpenseRepo = dataSource.getRepository(ExtraordinaryExpense);
+  const reserveFundRepo = dataSource.getRepository(ReserveFundTransaction);
+  const bankTransactionRepo = dataSource.getRepository(BankTransaction);
+
+  // categories
+  const maintenanceCat = categoryRepo.create({ name: 'Maintenance', type: CategoryType.MAINTENANCE });
+  const otherCat = categoryRepo.create({ name: 'Misc', type: CategoryType.OTHER });
+  await categoryRepo.save([maintenanceCat, otherCat]);
+
+  // residents
+  const john = residentRepo.create({ name: 'John Doe', unitNumber: 'A1', email: 'john@example.com' });
+  const jane = residentRepo.create({ name: 'Jane Smith', unitNumber: 'B2', email: 'jane@example.com' });
+  await residentRepo.save([john, jane]);
+
+  // payments
+  const payment1 = paymentRepo.create({ resident: john, category: maintenanceCat, amount: 100, method: PaymentMethod.TRANSFER });
+  const payment2 = paymentRepo.create({ resident: jane, category: otherCat, amount: 150, method: PaymentMethod.CARD });
+  await paymentRepo.save([payment1, payment2]);
+
+  // budget and items
+  const budget = budgetRepo.create({ year: new Date().getFullYear() });
+  await budgetRepo.save(budget);
+  const item1 = budgetItemRepo.create({ budget, category: maintenanceCat, plannedAmount: 1000, actualAmount: 200 });
+  const item2 = budgetItemRepo.create({ budget, category: otherCat, plannedAmount: 500, actualAmount: 100 });
+  await budgetItemRepo.save([item1, item2]);
+
+  // provider expenses
+  const expense = providerExpenseRepo.create({ providerName: 'CleanCo', serviceCategory: maintenanceCat, totalAmount: 300 });
+  await providerExpenseRepo.save(expense);
+
+  // delinquencies
+  const delinquency = delinquencyRepo.create({ description: 'Late fee', amount: 50 });
+  await delinquencyRepo.save(delinquency);
+
+  // extraordinary expenses
+  const extraExpense = extraordinaryExpenseRepo.create({ concept: 'Roof repair', amount: 2000, approvedBy: 'Board' });
+  await extraordinaryExpenseRepo.save(extraExpense);
+
+  // reserve fund transactions
+  const reserveTx = reserveFundRepo.create({ amount: 500, type: 'INCOME', notes: 'Initial fund' });
+  await reserveFundRepo.save(reserveTx);
+
+  // bank transactions
+  const bankTx = bankTransactionRepo.create({ bankDate: new Date(), bankAmount: 500, matched: false, systemReference: 'initial' });
+  await bankTransactionRepo.save(bankTx);
+
+  console.log('Database seeded successfully');
+  await dataSource.destroy();
+}
+
+seed().catch((err) => {
+  console.error('Seeding failed', err);
+  dataSource.destroy();
+});
+


### PR DESCRIPTION
## Summary
- add a script to populate the SQLite database with sample records
- expose `npm run seed` command
- document seeding and Postman collection usage
- provide sample Postman collection covering API routes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848bd805668832184d7732585e7e16e