### PR TITLE
Add range-based monthly balance report

### DIFF
--- a/docs/finance-api.postman_collection.json
+++ b/docs/finance-api.postman_collection.json
@@ -149,6 +149,7 @@
       "name": "Reports",
       "item": [
         { "name": "Monthly balance", "request": { "method": "GET", "url": "{{baseUrl}}/reports/monthly-balance?month=1&year=2025" } },
+        { "name": "Monthly balance range", "request": { "method": "GET", "url": "{{baseUrl}}/reports/monthly-balance-range?start=2025-01-01&end=2025-06-30" } },
         { "name": "Income vs expense", "request": { "method": "GET", "url": "{{baseUrl}}/reports/income-expense?start=2025-01-01&end=2025-02-01" } }
       ]
     }

--- a/src/modules/reports/reports.controller.ts
+++ b/src/modules/reports/reports.controller.ts
@@ -10,6 +10,17 @@ export class ReportsController {
     return this.reportsService.monthlyBalance(Number(month), Number(year));
   }
 
+  @Get('monthly-balance-range')
+  monthlyBalanceRange(
+    @Query('start') start: string,
+    @Query('end') end: string,
+  ) {
+    return this.reportsService.monthlyBalanceRange(
+      new Date(start),
+      new Date(end),
+    );
+  }
+
   @Get('income-expense')
   incomeExpense(@Query('start') start: string, @Query('end') end: string) {
     return this.reportsService.incomeExpenseStatement(

--- a/src/modules/reports/reports.service.ts
+++ b/src/modules/reports/reports.service.ts
@@ -57,6 +57,29 @@ export class ReportsService {
     };
   }
 
+  async monthlyBalanceRange(start: Date, end: Date) {
+    const results = [] as {
+      year: number;
+      month: number;
+      incomes: number;
+      expenses: number;
+      balance: number;
+    }[];
+
+    let current = new Date(start.getFullYear(), start.getMonth(), 1);
+    const last = new Date(end.getFullYear(), end.getMonth(), 1);
+
+    while (current <= last) {
+      const year = current.getFullYear();
+      const month = current.getMonth() + 1;
+      const data = await this.monthlyBalance(month, year);
+      results.push({ year, month, ...data });
+      current.setMonth(current.getMonth() + 1);
+    }
+
+    return results;
+  }
+
   async incomeExpenseStatement(start: Date, end: Date) {
     const payments = await this.paymentRepo.find({
       where: { paymentDate: Between(start, end) },


### PR DESCRIPTION
## Summary
- extend reports service with `monthlyBalanceRange`
- expose new `GET /reports/monthly-balance-range` endpoint
- document new endpoint in Postman collection

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a21592524832182adf6901d83a879